### PR TITLE
feat: formatting of nft prices

### DIFF
--- a/src/format.test.ts
+++ b/src/format.test.ts
@@ -97,7 +97,7 @@ it('formats Swap text input/output numbers correctly', () => {
 
 it('formats NFT numbers correctly', () => {
   expect(formatNumber(1234567000000000, NumberType.NFTTokenFloorPrice)).toBe('1.23e15')
-  expect(formatNumber(1002345, NumberType.NFTTokenFloorPrice)).toBe('1.00M')
+  expect(formatNumber(1002345, NumberType.NFTTokenFloorPrice)).toBe('1M')
   expect(formatNumber(1234, NumberType.NFTTokenFloorPrice)).toBe('1.23K')
   expect(formatNumber(12.34467, NumberType.NFTTokenFloorPrice)).toBe('12.34')
   expect(formatNumber(12.1, NumberType.NFTTokenFloorPrice)).toBe('12.1')
@@ -109,9 +109,10 @@ it('formats NFT numbers correctly', () => {
   expect(formatNumber(12.1, NumberType.NFTTokenFloorPriceTrailingZeros)).toBe('12.10')
   expect(formatNumber(0.09001, NumberType.NFTTokenFloorPriceTrailingZeros)).toBe('0.090')
 
-  expect(formatNumber(1234576, NumberType.NFTCollectionStats)).toBe('1.2M')
-  expect(formatNumber(234567, NumberType.NFTCollectionStats)).toBe('234.6K')
-  expect(formatNumber(999, NumberType.NFTCollectionStats)).toBe('999')
-  expect(formatNumber(0, NumberType.NFTCollectionStats)).toBe('0')
-  expect(formatNumber(12.1, NumberType.NFTCollectionStats)).toBe('12.1')
+  expect(formatNumber(0.987654321, NumberType.NFTCollectionStats)).toBe('0.98765')
+  expect(formatNumber(0.9, NumberType.NFTCollectionStats)).toBe('0.9')
+  expect(formatNumber(76543.21, NumberType.NFTCollectionStats)).toBe('76543.2')
+  expect(formatNumber(7.60000054321, NumberType.NFTCollectionStats)).toBe('7.6')
+  expect(formatNumber(1234567890, NumberType.NFTCollectionStats)).toBe('1.23457B')
+  expect(formatNumber(1234567000000000, NumberType.NFTCollectionStats)).toBe('1.23457e15')
 })

--- a/src/format.test.ts
+++ b/src/format.test.ts
@@ -100,10 +100,14 @@ it('formats NFT numbers correctly', () => {
   expect(formatNumber(1002345, NumberType.NFTTokenFloorPrice)).toBe('1.00M')
   expect(formatNumber(1234, NumberType.NFTTokenFloorPrice)).toBe('1.23K')
   expect(formatNumber(12.34467, NumberType.NFTTokenFloorPrice)).toBe('12.34')
+  expect(formatNumber(12.1, NumberType.NFTTokenFloorPrice)).toBe('12.1')
   expect(formatNumber(0.00909, NumberType.NFTTokenFloorPrice)).toBe('0.009')
-  expect(formatNumber(0.09001, NumberType.NFTTokenFloorPrice)).toBe('0.090')
+  expect(formatNumber(0.09001, NumberType.NFTTokenFloorPrice)).toBe('0.09')
   expect(formatNumber(0.00099, NumberType.NFTTokenFloorPrice)).toBe('<0.001')
   expect(formatNumber(0, NumberType.NFTTokenFloorPrice)).toBe('0')
+
+  expect(formatNumber(12.1, NumberType.NFTTokenFloorPriceTrailingZeros)).toBe('12.10')
+  expect(formatNumber(0.09001, NumberType.NFTTokenFloorPriceTrailingZeros)).toBe('0.090')
 
   expect(formatNumber(1234576, NumberType.NFTCollectionStats)).toBe('1.2M')
   expect(formatNumber(234567, NumberType.NFTCollectionStats)).toBe('234.6K')

--- a/src/format.test.ts
+++ b/src/format.test.ts
@@ -113,4 +113,5 @@ it('formats NFT numbers correctly', () => {
   expect(formatNumber(234567, NumberType.NFTCollectionStats)).toBe('234.6K')
   expect(formatNumber(999, NumberType.NFTCollectionStats)).toBe('999')
   expect(formatNumber(0, NumberType.NFTCollectionStats)).toBe('0')
+  expect(formatNumber(12.1, NumberType.NFTCollectionStats)).toBe('12.1')
 })

--- a/src/format.ts
+++ b/src/format.ts
@@ -23,12 +23,6 @@ const FIVE_DECIMALS_MAX_TWO_DECIMALS_MIN_NO_COMMAS = new Intl.NumberFormat('en-U
   useGrouping: false,
 })
 
-const NO_DECIMALS = new Intl.NumberFormat('en-US', {
-  notation: 'standard',
-  maximumFractionDigits: 0,
-  minimumFractionDigits: 0,
-})
-
 const THREE_DECIMALS_NO_TRAILING_ZEROS = new Intl.NumberFormat('en-US', {
   notation: 'standard',
   maximumFractionDigits: 3,
@@ -66,12 +60,6 @@ const TWO_DECIMALS_USD = new Intl.NumberFormat('en-US', {
   minimumFractionDigits: 2,
   currency: 'USD',
   style: 'currency',
-})
-
-const SHORTHAND_ONE_DECIMAL = new Intl.NumberFormat('en-US', {
-  notation: 'compact',
-  minimumFractionDigits: 1,
-  maximumFractionDigits: 1,
 })
 
 const SHORTHAND_TWO_DECIMALS = new Intl.NumberFormat('en-US', {

--- a/src/format.ts
+++ b/src/format.ts
@@ -39,7 +39,7 @@ const THREE_DECIMALS_TRAILING_ZEROS = new Intl.NumberFormat('en-US', {
 const THREE_DECIMALS_USD = new Intl.NumberFormat('en-US', {
   notation: 'standard',
   maximumFractionDigits: 3,
-  minimumFractionDigits: 1,
+  minimumFractionDigits: 3,
   currency: 'USD',
   style: 'currency',
 })

--- a/src/format.ts
+++ b/src/format.ts
@@ -27,18 +27,30 @@ const NO_DECIMALS = new Intl.NumberFormat('en-US', {
 const THREE_DECIMALS = new Intl.NumberFormat('en-US', {
   notation: 'standard',
   maximumFractionDigits: 3,
+  minimumFractionDigits: 1,
+})
+
+const THREE_DECIMALS_TRAILING_ZEROS = new Intl.NumberFormat('en-US', {
+  notation: 'standard',
+  maximumFractionDigits: 3,
   minimumFractionDigits: 3,
 })
 
 const THREE_DECIMALS_USD = new Intl.NumberFormat('en-US', {
   notation: 'standard',
   maximumFractionDigits: 3,
-  minimumFractionDigits: 3,
+  minimumFractionDigits: 1,
   currency: 'USD',
   style: 'currency',
 })
 
 const TWO_DECIMALS = new Intl.NumberFormat('en-US', {
+  notation: 'standard',
+  maximumFractionDigits: 2,
+  minimumFractionDigits: 1,
+})
+
+const TWO_DECIMALS_TRAILING_ZEROS = new Intl.NumberFormat('en-US', {
   notation: 'standard',
   maximumFractionDigits: 2,
   minimumFractionDigits: 2,
@@ -138,8 +150,8 @@ type FormatterRule =
 const tokenNonTxFormatter: FormatterRule[] = [
   { exact: 0, formatter: '0' },
   { upperBound: 0.001, formatter: '<0.001' },
-  { upperBound: 1, formatter: THREE_DECIMALS },
-  { upperBound: 1e6, formatter: TWO_DECIMALS },
+  { upperBound: 1, formatter: THREE_DECIMALS_TRAILING_ZEROS },
+  { upperBound: 1e6, formatter: TWO_DECIMALS_TRAILING_ZEROS },
   { upperBound: 1e15, formatter: SHORTHAND_TWO_DECIMALS },
   { upperBound: Infinity, formatter: SCIENTIFIC },
 ]
@@ -149,7 +161,7 @@ const tokenTxFormatter: FormatterRule[] = [
   { upperBound: 0.00001, formatter: '<0.00001' },
   { upperBound: 1, formatter: FIVE_DECIMALS_MAX_TWO_DECIMALS_MIN },
   { upperBound: 10000, formatter: SIX_SIG_FIGS_TWO_DECIMALS },
-  { upperBound: Infinity, formatter: TWO_DECIMALS },
+  { upperBound: Infinity, formatter: TWO_DECIMALS_TRAILING_ZEROS },
 ]
 
 const swapTradeAmountFormatter: FormatterRule[] = [
@@ -199,6 +211,15 @@ const ntfTokenFloorPriceFormatter: FormatterRule[] = [
   { upperBound: Infinity, formatter: SCIENTIFIC },
 ]
 
+const ntfTokenFloorPriceFormatterTrailingZeros: FormatterRule[] = [
+  { exact: 0, formatter: '0' },
+  { upperBound: 0.001, formatter: '<0.001' },
+  { upperBound: 1, formatter: THREE_DECIMALS_TRAILING_ZEROS },
+  { upperBound: 1000, formatter: TWO_DECIMALS_TRAILING_ZEROS },
+  { upperBound: 1e15, formatter: SHORTHAND_TWO_DECIMALS },
+  { upperBound: Infinity, formatter: SCIENTIFIC },
+]
+
 const ntfCollectionStatsFormatter: FormatterRule[] = [
   { upperBound: 1000, formatter: NO_DECIMALS },
   { upperBound: Infinity, formatter: SHORTHAND_ONE_DECIMAL },
@@ -235,6 +256,9 @@ export enum NumberType {
 
   // nft collection stats like number of items, holder, and sales
   NFTCollectionStats = 'nft-collection-stats',
+
+  // nft floor price with trailing zeros
+  NFTTokenFloorPriceTrailingZeros = 'nft-token-floor-price-trailing-zeros',
 }
 
 const TYPE_TO_FORMATTER_RULES = {
@@ -247,6 +271,7 @@ const TYPE_TO_FORMATTER_RULES = {
   [NumberType.FiatTokenStats]: fiatTokenStatsFormatter,
   [NumberType.FiatGasPrice]: fiatGasPriceFormatter,
   [NumberType.NFTTokenFloorPrice]: ntfTokenFloorPriceFormatter,
+  [NumberType.NFTTokenFloorPriceTrailingZeros]: ntfTokenFloorPriceFormatterTrailingZeros,
   [NumberType.NFTCollectionStats]: ntfCollectionStatsFormatter,
 }
 

--- a/src/format.ts
+++ b/src/format.ts
@@ -5,6 +5,11 @@ import { Nullish } from './types'
 // Number formatting follows the standards laid out in this spec:
 // https://www.notion.so/uniswaplabs/Number-standards-fbb9f533f10e4e22820722c2f66d23c0
 
+const FIVE_DECIMALS_NO_TRAILING_ZEROS = new Intl.NumberFormat('en-US', {
+  notation: 'standard',
+  maximumFractionDigits: 5,
+})
+
 const FIVE_DECIMALS_MAX_TWO_DECIMALS_MIN = new Intl.NumberFormat('en-US', {
   notation: 'standard',
   maximumFractionDigits: 5,
@@ -24,13 +29,13 @@ const NO_DECIMALS = new Intl.NumberFormat('en-US', {
   minimumFractionDigits: 0,
 })
 
-const THREE_DECIMALS = new Intl.NumberFormat('en-US', {
+const THREE_DECIMALS_NO_TRAILING_ZEROS = new Intl.NumberFormat('en-US', {
   notation: 'standard',
   maximumFractionDigits: 3,
-  minimumFractionDigits: 1,
+  minimumFractionDigits: 0,
 })
 
-const THREE_DECIMALS_TRAILING_ZEROS = new Intl.NumberFormat('en-US', {
+const THREE_DECIMALS = new Intl.NumberFormat('en-US', {
   notation: 'standard',
   maximumFractionDigits: 3,
   minimumFractionDigits: 3,
@@ -44,13 +49,12 @@ const THREE_DECIMALS_USD = new Intl.NumberFormat('en-US', {
   style: 'currency',
 })
 
-const TWO_DECIMALS = new Intl.NumberFormat('en-US', {
+const TWO_DECIMALS_NO_TRAILING_ZEROS = new Intl.NumberFormat('en-US', {
   notation: 'standard',
   maximumFractionDigits: 2,
-  minimumFractionDigits: 1,
 })
 
-const TWO_DECIMALS_TRAILING_ZEROS = new Intl.NumberFormat('en-US', {
+const TWO_DECIMALS = new Intl.NumberFormat('en-US', {
   notation: 'standard',
   maximumFractionDigits: 2,
   minimumFractionDigits: 2,
@@ -76,6 +80,16 @@ const SHORTHAND_TWO_DECIMALS = new Intl.NumberFormat('en-US', {
   maximumFractionDigits: 2,
 })
 
+const SHORTHAND_TWO_DECIMALS_NO_TRAILING_ZEROS = new Intl.NumberFormat('en-US', {
+  notation: 'compact',
+  maximumFractionDigits: 2,
+})
+
+const SHORTHAND_FIVE_DECIMALS_NO_TRAILING_ZEROS = new Intl.NumberFormat('en-US', {
+  notation: 'compact',
+  maximumFractionDigits: 5,
+})
+
 const SHORTHAND_USD_TWO_DECIMALS = new Intl.NumberFormat('en-US', {
   notation: 'compact',
   minimumFractionDigits: 2,
@@ -95,6 +109,11 @@ const SHORTHAND_USD_ONE_DECIMAL = new Intl.NumberFormat('en-US', {
 const SCIENTIFIC = new Intl.NumberFormat('en-US', {
   notation: 'scientific',
   maximumSignificantDigits: 3,
+})
+
+const SCIENTIFIC_SIX_DIGITS = new Intl.NumberFormat('en-US', {
+  notation: 'scientific',
+  maximumSignificantDigits: 6,
 })
 
 const SCIENTIFIC_USD = new Intl.NumberFormat('en-US', {
@@ -150,8 +169,8 @@ type FormatterRule =
 const tokenNonTxFormatter: FormatterRule[] = [
   { exact: 0, formatter: '0' },
   { upperBound: 0.001, formatter: '<0.001' },
-  { upperBound: 1, formatter: THREE_DECIMALS_TRAILING_ZEROS },
-  { upperBound: 1e6, formatter: TWO_DECIMALS_TRAILING_ZEROS },
+  { upperBound: 1, formatter: THREE_DECIMALS },
+  { upperBound: 1e6, formatter: TWO_DECIMALS },
   { upperBound: 1e15, formatter: SHORTHAND_TWO_DECIMALS },
   { upperBound: Infinity, formatter: SCIENTIFIC },
 ]
@@ -161,7 +180,7 @@ const tokenTxFormatter: FormatterRule[] = [
   { upperBound: 0.00001, formatter: '<0.00001' },
   { upperBound: 1, formatter: FIVE_DECIMALS_MAX_TWO_DECIMALS_MIN },
   { upperBound: 10000, formatter: SIX_SIG_FIGS_TWO_DECIMALS },
-  { upperBound: Infinity, formatter: TWO_DECIMALS_TRAILING_ZEROS },
+  { upperBound: Infinity, formatter: TWO_DECIMALS },
 ]
 
 const swapTradeAmountFormatter: FormatterRule[] = [
@@ -202,7 +221,7 @@ const fiatGasPriceFormatter: FormatterRule[] = [
 
 const fiatTokenQuantityFormatter = [{ exact: 0, formatter: '$0.00' }, ...fiatGasPriceFormatter]
 
-const ntfTokenFloorPriceFormatter: FormatterRule[] = [
+const ntfTokenFloorPriceFormatterTrailingZeros: FormatterRule[] = [
   { exact: 0, formatter: '0' },
   { upperBound: 0.001, formatter: '<0.001' },
   { upperBound: 1, formatter: THREE_DECIMALS },
@@ -211,18 +230,22 @@ const ntfTokenFloorPriceFormatter: FormatterRule[] = [
   { upperBound: Infinity, formatter: SCIENTIFIC },
 ]
 
-const ntfTokenFloorPriceFormatterTrailingZeros: FormatterRule[] = [
+const ntfTokenFloorPriceFormatter: FormatterRule[] = [
   { exact: 0, formatter: '0' },
   { upperBound: 0.001, formatter: '<0.001' },
-  { upperBound: 1, formatter: THREE_DECIMALS_TRAILING_ZEROS },
-  { upperBound: 1000, formatter: TWO_DECIMALS_TRAILING_ZEROS },
-  { upperBound: 1e15, formatter: SHORTHAND_TWO_DECIMALS },
+  { upperBound: 1, formatter: THREE_DECIMALS_NO_TRAILING_ZEROS },
+  { upperBound: 1000, formatter: TWO_DECIMALS_NO_TRAILING_ZEROS },
+  { upperBound: 1e15, formatter: SHORTHAND_TWO_DECIMALS_NO_TRAILING_ZEROS },
   { upperBound: Infinity, formatter: SCIENTIFIC },
 ]
 
 const ntfCollectionStatsFormatter: FormatterRule[] = [
-  { upperBound: 1000, formatter: NO_DECIMALS },
-  { upperBound: Infinity, formatter: SHORTHAND_ONE_DECIMAL },
+  { exact: 0, formatter: '0' },
+  { upperBound: 0.00001, formatter: '<0.00001' },
+  { upperBound: 1, formatter: FIVE_DECIMALS_NO_TRAILING_ZEROS },
+  { upperBound: 1e6, formatter: SIX_SIG_FIGS_NO_COMMAS },
+  { upperBound: 1e15, formatter: SHORTHAND_FIVE_DECIMALS_NO_TRAILING_ZEROS },
+  { upperBound: Infinity, formatter: SCIENTIFIC_SIX_DIGITS },
 ]
 
 export enum NumberType {


### PR DESCRIPTION
While working on a project, I had a request to show NFT prices with trailing zeros in one place. I was pretty sure this is not supported because it's against the spec in the Notion document. I was surprised to realize it behaves this way by default. Shipped a fix + added one more formatter so I can format the price with trailing zeros in a few places.