### PR TITLE
chore: updates to the number formatter

### DIFF
--- a/src/format.test.ts
+++ b/src/format.test.ts
@@ -1,7 +1,7 @@
 import { formatNumber, NumberType } from './format'
 
 it('formats token reference numbers correctly', () => {
-  expect(formatNumber(1234567000000000, NumberType.TokenNonTx)).toBe('1.23e15')
+  expect(formatNumber(1234567000000000, NumberType.TokenNonTx)).toBe('>999T')
   expect(formatNumber(1002345, NumberType.TokenNonTx)).toBe('1.00M')
   expect(formatNumber(1234, NumberType.TokenNonTx)).toBe('1,234.00')
   expect(formatNumber(0.00909, NumberType.TokenNonTx)).toBe('0.009')
@@ -37,8 +37,8 @@ it('formats fiat estimates on token details pages correctly', () => {
   expect(formatNumber(0.001231, NumberType.FiatTokenDetails)).toBe('$0.00123')
   expect(formatNumber(0.00001231, NumberType.FiatTokenDetails)).toBe('$0.0000123')
 
-  expect(formatNumber(0.0000001234, NumberType.FiatTokenDetails)).toBe('$1.23e-7')
-  expect(formatNumber(0.000000009876, NumberType.FiatTokenDetails)).toBe('$9.88e-9')
+  expect(formatNumber(0.0000001234, NumberType.FiatTokenDetails)).toBe('$0.000000123')
+  expect(formatNumber(0.000000009876, NumberType.FiatTokenDetails)).toBe('<$0.00000001')
 })
 
 it('formats fiat estimates for tokens correctly', () => {
@@ -49,8 +49,8 @@ it('formats fiat estimates for tokens correctly', () => {
   expect(formatNumber(0.001231, NumberType.FiatTokenPrice)).toBe('$0.00123')
   expect(formatNumber(0.00001231, NumberType.FiatTokenPrice)).toBe('$0.0000123')
 
-  expect(formatNumber(0.0000001234, NumberType.FiatTokenPrice)).toBe('$1.23e-7')
-  expect(formatNumber(0.000000009876, NumberType.FiatTokenPrice)).toBe('$9.88e-9')
+  expect(formatNumber(0.0000001234, NumberType.FiatTokenPrice)).toBe('$0.000000123')
+  expect(formatNumber(0.000000009876, NumberType.FiatTokenPrice)).toBe('<$0.00000001')
 })
 
 it('formats fiat estimates for token stats correctly', () => {
@@ -96,7 +96,7 @@ it('formats Swap text input/output numbers correctly', () => {
 })
 
 it('formats NFT numbers correctly', () => {
-  expect(formatNumber(1234567000000000, NumberType.NFTTokenFloorPrice)).toBe('1.23e15')
+  expect(formatNumber(1234567000000000, NumberType.NFTTokenFloorPrice)).toBe('>999T')
   expect(formatNumber(1002345, NumberType.NFTTokenFloorPrice)).toBe('1.00M')
   expect(formatNumber(1234, NumberType.NFTTokenFloorPrice)).toBe('1.23K')
   expect(formatNumber(12.34467, NumberType.NFTTokenFloorPrice)).toBe('12.34')

--- a/src/format.test.ts
+++ b/src/format.test.ts
@@ -114,5 +114,5 @@ it('formats NFT numbers correctly', () => {
   expect(formatNumber(76543.21, NumberType.NFTCollectionStats)).toBe('76543.2')
   expect(formatNumber(7.60000054321, NumberType.NFTCollectionStats)).toBe('7.6')
   expect(formatNumber(1234567890, NumberType.NFTCollectionStats)).toBe('1.23457B')
-  expect(formatNumber(1234567000000000, NumberType.NFTCollectionStats)).toBe('1.23457e15')
+  expect(formatNumber(1234567000000000, NumberType.NFTCollectionStats)).toBe('>999T')
 })

--- a/src/format.test.ts
+++ b/src/format.test.ts
@@ -97,22 +97,16 @@ it('formats Swap text input/output numbers correctly', () => {
 
 it('formats NFT numbers correctly', () => {
   expect(formatNumber(1234567000000000, NumberType.NFTTokenFloorPrice)).toBe('>999T')
-  expect(formatNumber(1002345, NumberType.NFTTokenFloorPrice)).toBe('1M')
+  expect(formatNumber(1002345, NumberType.NFTTokenFloorPrice)).toBe('1.00M')
   expect(formatNumber(1234, NumberType.NFTTokenFloorPrice)).toBe('1.23K')
   expect(formatNumber(12.34467, NumberType.NFTTokenFloorPrice)).toBe('12.34')
-  expect(formatNumber(12.1, NumberType.NFTTokenFloorPrice)).toBe('12.1')
   expect(formatNumber(0.00909, NumberType.NFTTokenFloorPrice)).toBe('0.009')
-  expect(formatNumber(0.09001, NumberType.NFTTokenFloorPrice)).toBe('0.09')
+  expect(formatNumber(0.09001, NumberType.NFTTokenFloorPrice)).toBe('0.090')
   expect(formatNumber(0.00099, NumberType.NFTTokenFloorPrice)).toBe('<0.001')
   expect(formatNumber(0, NumberType.NFTTokenFloorPrice)).toBe('0')
 
-  expect(formatNumber(12.1, NumberType.NFTTokenFloorPriceTrailingZeros)).toBe('12.10')
-  expect(formatNumber(0.09001, NumberType.NFTTokenFloorPriceTrailingZeros)).toBe('0.090')
-
-  expect(formatNumber(0.987654321, NumberType.NFTCollectionStats)).toBe('0.98765')
-  expect(formatNumber(0.9, NumberType.NFTCollectionStats)).toBe('0.9')
-  expect(formatNumber(76543.21, NumberType.NFTCollectionStats)).toBe('76543.2')
-  expect(formatNumber(7.60000054321, NumberType.NFTCollectionStats)).toBe('7.6')
-  expect(formatNumber(1234567890, NumberType.NFTCollectionStats)).toBe('1.23457B')
-  expect(formatNumber(1234567000000000, NumberType.NFTCollectionStats)).toBe('>999T')
+  expect(formatNumber(1234576, NumberType.NFTCollectionStats)).toBe('1.2M')
+  expect(formatNumber(234567, NumberType.NFTCollectionStats)).toBe('234.6K')
+  expect(formatNumber(999, NumberType.NFTCollectionStats)).toBe('999')
+  expect(formatNumber(0, NumberType.NFTCollectionStats)).toBe('0')
 })

--- a/src/format.test.ts
+++ b/src/format.test.ts
@@ -97,16 +97,22 @@ it('formats Swap text input/output numbers correctly', () => {
 
 it('formats NFT numbers correctly', () => {
   expect(formatNumber(1234567000000000, NumberType.NFTTokenFloorPrice)).toBe('>999T')
-  expect(formatNumber(1002345, NumberType.NFTTokenFloorPrice)).toBe('1.00M')
+  expect(formatNumber(1002345, NumberType.NFTTokenFloorPrice)).toBe('1M')
   expect(formatNumber(1234, NumberType.NFTTokenFloorPrice)).toBe('1.23K')
   expect(formatNumber(12.34467, NumberType.NFTTokenFloorPrice)).toBe('12.34')
+  expect(formatNumber(12.1, NumberType.NFTTokenFloorPrice)).toBe('12.1')
   expect(formatNumber(0.00909, NumberType.NFTTokenFloorPrice)).toBe('0.009')
-  expect(formatNumber(0.09001, NumberType.NFTTokenFloorPrice)).toBe('0.090')
+  expect(formatNumber(0.09001, NumberType.NFTTokenFloorPrice)).toBe('0.09')
   expect(formatNumber(0.00099, NumberType.NFTTokenFloorPrice)).toBe('<0.001')
   expect(formatNumber(0, NumberType.NFTTokenFloorPrice)).toBe('0')
 
-  expect(formatNumber(1234576, NumberType.NFTCollectionStats)).toBe('1.2M')
-  expect(formatNumber(234567, NumberType.NFTCollectionStats)).toBe('234.6K')
-  expect(formatNumber(999, NumberType.NFTCollectionStats)).toBe('999')
-  expect(formatNumber(0, NumberType.NFTCollectionStats)).toBe('0')
+  expect(formatNumber(12.1, NumberType.NFTTokenFloorPriceTrailingZeros)).toBe('12.10')
+  expect(formatNumber(0.09001, NumberType.NFTTokenFloorPriceTrailingZeros)).toBe('0.090')
+
+  expect(formatNumber(0.987654321, NumberType.NFTCollectionStats)).toBe('0.98765')
+  expect(formatNumber(0.9, NumberType.NFTCollectionStats)).toBe('0.9')
+  expect(formatNumber(76543.21, NumberType.NFTCollectionStats)).toBe('76543.2')
+  expect(formatNumber(7.60000054321, NumberType.NFTCollectionStats)).toBe('7.6')
+  expect(formatNumber(1234567890, NumberType.NFTCollectionStats)).toBe('1.23457B')
+  expect(formatNumber(1234567000000000, NumberType.NFTCollectionStats)).toBe('>999T')
 })

--- a/src/format.ts
+++ b/src/format.ts
@@ -5,11 +5,6 @@ import { Nullish } from './types'
 // Number formatting follows the standards laid out in this spec:
 // https://www.notion.so/uniswaplabs/Number-standards-fbb9f533f10e4e22820722c2f66d23c0
 
-const FIVE_DECIMALS_NO_TRAILING_ZEROS = new Intl.NumberFormat('en-US', {
-  notation: 'standard',
-  maximumFractionDigits: 5,
-})
-
 const FIVE_DECIMALS_MAX_TWO_DECIMALS_MIN = new Intl.NumberFormat('en-US', {
   notation: 'standard',
   maximumFractionDigits: 5,
@@ -23,9 +18,9 @@ const FIVE_DECIMALS_MAX_TWO_DECIMALS_MIN_NO_COMMAS = new Intl.NumberFormat('en-U
   useGrouping: false,
 })
 
-const THREE_DECIMALS_NO_TRAILING_ZEROS = new Intl.NumberFormat('en-US', {
+const NO_DECIMALS = new Intl.NumberFormat('en-US', {
   notation: 'standard',
-  maximumFractionDigits: 3,
+  maximumFractionDigits: 0,
   minimumFractionDigits: 0,
 })
 
@@ -43,11 +38,6 @@ const THREE_DECIMALS_USD = new Intl.NumberFormat('en-US', {
   style: 'currency',
 })
 
-const TWO_DECIMALS_NO_TRAILING_ZEROS = new Intl.NumberFormat('en-US', {
-  notation: 'standard',
-  maximumFractionDigits: 2,
-})
-
 const TWO_DECIMALS = new Intl.NumberFormat('en-US', {
   notation: 'standard',
   maximumFractionDigits: 2,
@@ -62,20 +52,16 @@ const TWO_DECIMALS_USD = new Intl.NumberFormat('en-US', {
   style: 'currency',
 })
 
+const SHORTHAND_ONE_DECIMAL = new Intl.NumberFormat('en-US', {
+  notation: 'compact',
+  minimumFractionDigits: 1,
+  maximumFractionDigits: 1,
+})
+
 const SHORTHAND_TWO_DECIMALS = new Intl.NumberFormat('en-US', {
   notation: 'compact',
   minimumFractionDigits: 2,
   maximumFractionDigits: 2,
-})
-
-const SHORTHAND_TWO_DECIMALS_NO_TRAILING_ZEROS = new Intl.NumberFormat('en-US', {
-  notation: 'compact',
-  maximumFractionDigits: 2,
-})
-
-const SHORTHAND_FIVE_DECIMALS_NO_TRAILING_ZEROS = new Intl.NumberFormat('en-US', {
-  notation: 'compact',
-  maximumFractionDigits: 5,
 })
 
 const SHORTHAND_USD_TWO_DECIMALS = new Intl.NumberFormat('en-US', {
@@ -197,7 +183,7 @@ const portfolioBalanceFormatter: FormatterRule[] = [
   { upperBound: Infinity, formatter: TWO_DECIMALS_USD },
 ]
 
-const ntfTokenFloorPriceFormatterTrailingZeros: FormatterRule[] = [
+const ntfTokenFloorPriceFormatter: FormatterRule[] = [
   { exact: 0, formatter: '0' },
   { upperBound: 0.001, formatter: '<0.001' },
   { upperBound: 1, formatter: THREE_DECIMALS },
@@ -206,22 +192,9 @@ const ntfTokenFloorPriceFormatterTrailingZeros: FormatterRule[] = [
   { upperBound: Infinity, formatter: '>999T' },
 ]
 
-const ntfTokenFloorPriceFormatter: FormatterRule[] = [
-  { exact: 0, formatter: '0' },
-  { upperBound: 0.001, formatter: '<0.001' },
-  { upperBound: 1, formatter: THREE_DECIMALS_NO_TRAILING_ZEROS },
-  { upperBound: 1000, formatter: TWO_DECIMALS_NO_TRAILING_ZEROS },
-  { upperBound: 1e15, formatter: SHORTHAND_TWO_DECIMALS_NO_TRAILING_ZEROS },
-  { upperBound: Infinity, formatter: '>999T' },
-]
-
 const ntfCollectionStatsFormatter: FormatterRule[] = [
-  { exact: 0, formatter: '0' },
-  { upperBound: 0.00001, formatter: '<0.00001' },
-  { upperBound: 1, formatter: FIVE_DECIMALS_NO_TRAILING_ZEROS },
-  { upperBound: 1e6, formatter: SIX_SIG_FIGS_NO_COMMAS },
-  { upperBound: 1e15, formatter: SHORTHAND_FIVE_DECIMALS_NO_TRAILING_ZEROS },
-  { upperBound: Infinity, formatter: '>999T' },
+  { upperBound: 1000, formatter: NO_DECIMALS },
+  { upperBound: Infinity, formatter: SHORTHAND_ONE_DECIMAL },
 ]
 
 export enum NumberType {
@@ -258,9 +231,6 @@ export enum NumberType {
 
   // nft collection stats like number of items, holder, and sales
   NFTCollectionStats = 'nft-collection-stats',
-
-  // nft floor price with trailing zeros
-  NFTTokenFloorPriceTrailingZeros = 'nft-token-floor-price-trailing-zeros',
 }
 
 const TYPE_TO_FORMATTER_RULES = {
@@ -274,7 +244,6 @@ const TYPE_TO_FORMATTER_RULES = {
   [NumberType.FiatGasPrice]: fiatGasPriceFormatter,
   [NumberType.PortfolioBalance]: portfolioBalanceFormatter,
   [NumberType.NFTTokenFloorPrice]: ntfTokenFloorPriceFormatter,
-  [NumberType.NFTTokenFloorPriceTrailingZeros]: ntfTokenFloorPriceFormatterTrailingZeros,
   [NumberType.NFTCollectionStats]: ntfCollectionStatsFormatter,
 }
 

--- a/src/format.ts
+++ b/src/format.ts
@@ -1,4 +1,5 @@
 import { Currency, CurrencyAmount, Percent, Price } from '@uniswap/sdk-core'
+
 import { Nullish } from './types'
 
 // Number formatting follows the standards laid out in this spec:
@@ -261,11 +262,7 @@ function getFormatterRule(input: number, type: NumberType) {
   throw new Error(`formatter for type ${type} not configured correctly`)
 }
 
-export function formatNumber(
-  input: Nullish<number>,
-  type: NumberType = NumberType.TokenNonTx,
-  placeholder: string = '-'
-) {
+export function formatNumber(input: Nullish<number>, type: NumberType = NumberType.TokenNonTx, placeholder = '-') {
   if (input === null || input === undefined) {
     return placeholder
   }
@@ -289,10 +286,7 @@ export function formatPriceImpact(priceImpact: Percent | undefined) {
   return `${priceImpact.multiply(-1).toFixed(3)}%`
 }
 
-export function formatPrice(
-  price: Nullish<Price<Currency, Currency>>,
-  type: NumberType = NumberType.FiatTokenPrice
-) {
+export function formatPrice(price: Nullish<Price<Currency, Currency>>, type: NumberType = NumberType.FiatTokenPrice) {
   if (price === null || price === undefined) {
     return '-'
   }
@@ -320,9 +314,6 @@ export function formatNumberOrString(price: Nullish<number | string>, type: Numb
   return formatNumber(price, type)
 }
 
-export function formatUSDPrice(
-  price: Nullish<number | string>,
-  type: NumberType = NumberType.FiatTokenPrice
-) {
+export function formatUSDPrice(price: Nullish<number | string>, type: NumberType = NumberType.FiatTokenPrice) {
   return formatNumberOrString(price, type)
 }

--- a/src/format.ts
+++ b/src/format.ts
@@ -5,6 +5,11 @@ import { Nullish } from './types'
 // Number formatting follows the standards laid out in this spec:
 // https://www.notion.so/uniswaplabs/Number-standards-fbb9f533f10e4e22820722c2f66d23c0
 
+const FIVE_DECIMALS_NO_TRAILING_ZEROS = new Intl.NumberFormat('en-US', {
+  notation: 'standard',
+  maximumFractionDigits: 5,
+})
+
 const FIVE_DECIMALS_MAX_TWO_DECIMALS_MIN = new Intl.NumberFormat('en-US', {
   notation: 'standard',
   maximumFractionDigits: 5,
@@ -18,9 +23,9 @@ const FIVE_DECIMALS_MAX_TWO_DECIMALS_MIN_NO_COMMAS = new Intl.NumberFormat('en-U
   useGrouping: false,
 })
 
-const NO_DECIMALS = new Intl.NumberFormat('en-US', {
+const THREE_DECIMALS_NO_TRAILING_ZEROS = new Intl.NumberFormat('en-US', {
   notation: 'standard',
-  maximumFractionDigits: 0,
+  maximumFractionDigits: 3,
   minimumFractionDigits: 0,
 })
 
@@ -38,6 +43,11 @@ const THREE_DECIMALS_USD = new Intl.NumberFormat('en-US', {
   style: 'currency',
 })
 
+const TWO_DECIMALS_NO_TRAILING_ZEROS = new Intl.NumberFormat('en-US', {
+  notation: 'standard',
+  maximumFractionDigits: 2,
+})
+
 const TWO_DECIMALS = new Intl.NumberFormat('en-US', {
   notation: 'standard',
   maximumFractionDigits: 2,
@@ -52,16 +62,20 @@ const TWO_DECIMALS_USD = new Intl.NumberFormat('en-US', {
   style: 'currency',
 })
 
-const SHORTHAND_ONE_DECIMAL = new Intl.NumberFormat('en-US', {
-  notation: 'compact',
-  minimumFractionDigits: 1,
-  maximumFractionDigits: 1,
-})
-
 const SHORTHAND_TWO_DECIMALS = new Intl.NumberFormat('en-US', {
   notation: 'compact',
   minimumFractionDigits: 2,
   maximumFractionDigits: 2,
+})
+
+const SHORTHAND_TWO_DECIMALS_NO_TRAILING_ZEROS = new Intl.NumberFormat('en-US', {
+  notation: 'compact',
+  maximumFractionDigits: 2,
+})
+
+const SHORTHAND_FIVE_DECIMALS_NO_TRAILING_ZEROS = new Intl.NumberFormat('en-US', {
+  notation: 'compact',
+  maximumFractionDigits: 5,
 })
 
 const SHORTHAND_USD_TWO_DECIMALS = new Intl.NumberFormat('en-US', {
@@ -183,7 +197,7 @@ const portfolioBalanceFormatter: FormatterRule[] = [
   { upperBound: Infinity, formatter: TWO_DECIMALS_USD },
 ]
 
-const ntfTokenFloorPriceFormatter: FormatterRule[] = [
+const ntfTokenFloorPriceFormatterTrailingZeros: FormatterRule[] = [
   { exact: 0, formatter: '0' },
   { upperBound: 0.001, formatter: '<0.001' },
   { upperBound: 1, formatter: THREE_DECIMALS },
@@ -192,9 +206,22 @@ const ntfTokenFloorPriceFormatter: FormatterRule[] = [
   { upperBound: Infinity, formatter: '>999T' },
 ]
 
+const ntfTokenFloorPriceFormatter: FormatterRule[] = [
+  { exact: 0, formatter: '0' },
+  { upperBound: 0.001, formatter: '<0.001' },
+  { upperBound: 1, formatter: THREE_DECIMALS_NO_TRAILING_ZEROS },
+  { upperBound: 1000, formatter: TWO_DECIMALS_NO_TRAILING_ZEROS },
+  { upperBound: 1e15, formatter: SHORTHAND_TWO_DECIMALS_NO_TRAILING_ZEROS },
+  { upperBound: Infinity, formatter: '>999T' },
+]
+
 const ntfCollectionStatsFormatter: FormatterRule[] = [
-  { upperBound: 1000, formatter: NO_DECIMALS },
-  { upperBound: Infinity, formatter: SHORTHAND_ONE_DECIMAL },
+  { exact: 0, formatter: '0' },
+  { upperBound: 0.00001, formatter: '<0.00001' },
+  { upperBound: 1, formatter: FIVE_DECIMALS_NO_TRAILING_ZEROS },
+  { upperBound: 1e6, formatter: SIX_SIG_FIGS_NO_COMMAS },
+  { upperBound: 1e15, formatter: SHORTHAND_FIVE_DECIMALS_NO_TRAILING_ZEROS },
+  { upperBound: Infinity, formatter: '>999T' },
 ]
 
 export enum NumberType {
@@ -231,6 +258,9 @@ export enum NumberType {
 
   // nft collection stats like number of items, holder, and sales
   NFTCollectionStats = 'nft-collection-stats',
+
+  // nft floor price with trailing zeros
+  NFTTokenFloorPriceTrailingZeros = 'nft-token-floor-price-trailing-zeros',
 }
 
 const TYPE_TO_FORMATTER_RULES = {
@@ -244,6 +274,7 @@ const TYPE_TO_FORMATTER_RULES = {
   [NumberType.FiatGasPrice]: fiatGasPriceFormatter,
   [NumberType.PortfolioBalance]: portfolioBalanceFormatter,
   [NumberType.NFTTokenFloorPrice]: ntfTokenFloorPriceFormatter,
+  [NumberType.NFTTokenFloorPriceTrailingZeros]: ntfTokenFloorPriceFormatterTrailingZeros,
   [NumberType.NFTCollectionStats]: ntfCollectionStatsFormatter,
 }
 

--- a/src/format.ts
+++ b/src/format.ts
@@ -212,7 +212,7 @@ const ntfTokenFloorPriceFormatter: FormatterRule[] = [
   { upperBound: 1, formatter: THREE_DECIMALS_NO_TRAILING_ZEROS },
   { upperBound: 1000, formatter: TWO_DECIMALS_NO_TRAILING_ZEROS },
   { upperBound: 1e15, formatter: SHORTHAND_TWO_DECIMALS_NO_TRAILING_ZEROS },
-  { upperBound: Infinity, formatter: SCIENTIFIC },
+  { upperBound: Infinity, formatter: '>999T' },
 ]
 
 const ntfCollectionStatsFormatter: FormatterRule[] = [
@@ -221,7 +221,7 @@ const ntfCollectionStatsFormatter: FormatterRule[] = [
   { upperBound: 1, formatter: FIVE_DECIMALS_NO_TRAILING_ZEROS },
   { upperBound: 1e6, formatter: SIX_SIG_FIGS_NO_COMMAS },
   { upperBound: 1e15, formatter: SHORTHAND_FIVE_DECIMALS_NO_TRAILING_ZEROS },
-  { upperBound: Infinity, formatter: SCIENTIFIC_SIX_DIGITS },
+  { upperBound: Infinity, formatter: '>999T' },
 ]
 
 export enum NumberType {


### PR DESCRIPTION
Some updates to the formatter based on revisions to the doc that Will made recently:
- no scientific notation anywhere
- special formatting case for overall portfolio balance