### PR TITLE
fix: typed data values typing

### DIFF
--- a/src/provider.ts
+++ b/src/provider.ts
@@ -16,7 +16,7 @@ export async function signTypedData(
   signer: JsonRpcSigner,
   domain: TypedDataDomain,
   types: Record<string, TypedDataField[]>,
-  value: Record<string, unknown>
+  value: Record<string, any> // eslint-disable-line @typescript-eslint/no-explicit-any
 ) {
   // Populate any ENS names (in-place)
   const populated = await _TypedDataEncoder.resolveNames(domain, types, value, (name: string) => {

--- a/src/provider.ts
+++ b/src/provider.ts
@@ -16,7 +16,9 @@ export async function signTypedData(
   signer: JsonRpcSigner,
   domain: TypedDataDomain,
   types: Record<string, TypedDataField[]>,
-  value: Record<string, any> // eslint-disable-line @typescript-eslint/no-explicit-any
+  // Use Record<string, any> for the value to match the JsonRpcSigner._signTypedData signature.
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  value: Record<string, any>
 ) {
   // Populate any ENS names (in-place)
   const populated = await _TypedDataEncoder.resolveNames(domain, types, value, (name: string) => {


### PR DESCRIPTION
Fixes the typing of signTypedData to match that of JsonRpcSigner._signTypedData, so that values can be passed directly (without type coercion).