### PR TITLE
fix: accomodate known wallets

### DIFF
--- a/src/provider.test.ts
+++ b/src/provider.test.ts
@@ -1,6 +1,6 @@
 import { JsonRpcProvider } from '@ethersproject/providers'
 
-import { INVALID_PARAMS_CODE, signTypedData } from './provider'
+import { signTypedData } from './provider'
 
 describe('provider', () => {
   describe('signTypedData', () => {
@@ -37,76 +37,102 @@ describe('provider', () => {
     }
 
     let signer
-    beforeEach(() => {
-      signer = new JsonRpcProvider().getSigner()
-      jest.spyOn(signer, 'getAddress').mockReturnValue(wallet)
-    })
 
-    it('signs using eth_signTypedData', async () => {
-      const send = jest.spyOn(signer.provider, 'send').mockImplementationOnce((method, params) => {
-        if (method === 'eth_signTypedData') return Promise.resolve()
+    describe('metamask', () => {
+      beforeEach(() => {
+        signer = new JsonRpcProvider('metamask').getSigner()
+        jest.spyOn(signer, 'getAddress').mockReturnValue(wallet)
       })
 
-      await signTypedData(signer, domain, types, value)
-      expect(send).toHaveBeenCalledTimes(1)
-      expect(send).toHaveBeenCalledWith('eth_signTypedData', [wallet, expect.anything()])
-      const data = send.mock.lastCall[1]?.[1]
-      expect(JSON.parse(data)).toEqual(expect.objectContaining({ domain, message: value }))
-    })
-
-    it('falls back to eth_signTypedData_v4 if the request has invalid params', async () => {
-      const send = jest
-        .spyOn(signer.provider, 'send')
-        .mockImplementationOnce((method) => {
-          if (method === 'eth_signTypedData') return Promise.reject({ code: INVALID_PARAMS_CODE })
-        })
-        .mockImplementationOnce((method, params) => {
+      it('signs using eth_signTypedData_v4', async () => {
+        const send = jest.spyOn(signer.provider, 'send').mockImplementationOnce((method, params) => {
           if (method === 'eth_signTypedData_v4') return Promise.resolve()
         })
-      jest.spyOn(console, 'warn').mockImplementation(() => undefined)
 
-      await signTypedData(signer, domain, types, value)
-      expect(console.warn).toHaveBeenCalledWith(expect.stringContaining('eth_signTypedData failed'), expect.anything())
-      expect(send).toHaveBeenCalledTimes(2)
-      expect(send).toHaveBeenCalledWith('eth_signTypedData', [wallet, expect.anything()])
-      expect(send).toHaveBeenCalledWith('eth_signTypedData_v4', [wallet, expect.anything()])
-      const data = send.mock.lastCall[1]?.[1]
-      expect(JSON.parse(data)).toEqual(expect.objectContaining({ domain, message: value }))
+        await signTypedData(signer, domain, types, value)
+        expect(send).toHaveBeenCalledTimes(1)
+        expect(send).toHaveBeenCalledWith('eth_signTypedData_v4', [wallet, expect.anything()])
+        const data = send.mock.lastCall[1]?.[1]
+        expect(JSON.parse(data)).toEqual(expect.objectContaining({ domain, message: value }))
+      })
     })
 
-    it.each(['not found', 'not implemented'])('falls back to eth_sign if eth_signTypedData is %s', async (message) => {
-      const send = jest
-        .spyOn(signer.provider, 'send')
-        .mockImplementationOnce((method) => {
-          if (method === 'eth_signTypedData') return Promise.reject({ message: `method ${message}` })
-        })
-        .mockImplementationOnce((method, params) => {
-          if (method === 'eth_sign') return Promise.resolve()
-        })
-      jest.spyOn(console, 'warn').mockImplementation(() => undefined)
-
-      await signTypedData(signer, domain, types, value)
-      expect(console.warn).toHaveBeenCalledWith(
-        expect.stringContaining('eth_signTypedData_* failed'),
-        expect.anything()
-      )
-      expect(send).toHaveBeenCalledTimes(2)
-      expect(send).toHaveBeenCalledWith('eth_signTypedData', [wallet, expect.anything()])
-      expect(send).toHaveBeenCalledWith('eth_sign', [wallet, expect.anything()])
-      const hash = send.mock.lastCall[1]?.[1]
-      expect(hash).toBe('0xbe609aee343fb3c4b28e1df9e632fca64fcfaede20f02e86244efddf30957bd2')
-    })
-
-    it('fails if rejected', async () => {
-      const send = jest.spyOn(signer.provider, 'send').mockImplementationOnce((method) => {
-        if (method === 'eth_signTypedData') return Promise.reject(new Error('User rejected'))
+    describe('EIP-1193', () => {
+      beforeEach(() => {
+        signer = new JsonRpcProvider().getSigner()
+        jest.spyOn(signer, 'getAddress').mockReturnValue(wallet)
       })
 
-      await expect(async () => await signTypedData(signer, domain, types, value)).rejects.toThrow('User rejected')
-      expect(send).toHaveBeenCalledTimes(1)
-      expect(send).toHaveBeenCalledWith('eth_signTypedData', [wallet, expect.anything()])
-      const data = send.mock.lastCall[1]?.[1]
-      expect(JSON.parse(data)).toEqual(expect.objectContaining({ domain, message: value }))
+      it('signs using eth_signTypedData', async () => {
+        const send = jest.spyOn(signer.provider, 'send').mockImplementationOnce((method, params) => {
+          if (method === 'eth_signTypedData') return Promise.resolve()
+        })
+
+        await signTypedData(signer, domain, types, value)
+        expect(send).toHaveBeenCalledTimes(1)
+        expect(send).toHaveBeenCalledWith('eth_signTypedData', [wallet, expect.anything()])
+        const data = send.mock.lastCall[1]?.[1]
+        expect(JSON.parse(data)).toEqual(expect.objectContaining({ domain, message: value }))
+      })
+
+      it('falls back to eth_signTypedData_v4 if the request has an unknown account', async () => {
+        const send = jest
+          .spyOn(signer.provider, 'send')
+          .mockImplementationOnce((method) => {
+            if (method === 'eth_signTypedData') return Promise.reject({ message: 'Unknown account: {...}' })
+          })
+          .mockImplementationOnce((method, params) => {
+            if (method === 'eth_signTypedData_v4') return Promise.resolve()
+          })
+        jest.spyOn(console, 'warn').mockImplementation(() => undefined)
+
+        await signTypedData(signer, domain, types, value)
+        expect(console.warn).toHaveBeenCalledWith(
+          expect.stringContaining('signTypedData: wallet expects historical parameter ordering, falling back to v4')
+        )
+        expect(send).toHaveBeenCalledTimes(2)
+        expect(send).toHaveBeenCalledWith('eth_signTypedData', [wallet, expect.anything()])
+        expect(send).toHaveBeenCalledWith('eth_signTypedData_v4', [wallet, expect.anything()])
+        const data = send.mock.lastCall[1]?.[1]
+        expect(JSON.parse(data)).toEqual(expect.objectContaining({ domain, message: value }))
+      })
+
+      it.each(['not found', 'not implemented'])(
+        'falls back to eth_sign if eth_signTypedData is %s',
+        async (message) => {
+          const send = jest
+            .spyOn(signer.provider, 'send')
+            .mockImplementationOnce((method) => {
+              if (method === 'eth_signTypedData') return Promise.reject({ message: `method ${message}` })
+            })
+            .mockImplementationOnce((method, params) => {
+              if (method === 'eth_sign') return Promise.resolve()
+            })
+          jest.spyOn(console, 'warn').mockImplementation(() => undefined)
+
+          await signTypedData(signer, domain, types, value)
+          expect(console.warn).toHaveBeenCalledWith(
+            expect.stringContaining('signTypedData: wallet does not implement EIP-712, falling back to sign')
+          )
+          expect(send).toHaveBeenCalledTimes(2)
+          expect(send).toHaveBeenCalledWith('eth_signTypedData', [wallet, expect.anything()])
+          expect(send).toHaveBeenCalledWith('eth_sign', [wallet, expect.anything()])
+          const hash = send.mock.lastCall[1]?.[1]
+          expect(hash).toBe('0xbe609aee343fb3c4b28e1df9e632fca64fcfaede20f02e86244efddf30957bd2')
+        }
+      )
+
+      it('fails if rejected', async () => {
+        const send = jest.spyOn(signer.provider, 'send').mockImplementationOnce((method) => {
+          if (method === 'eth_signTypedData') return Promise.reject(new Error('User rejected'))
+        })
+
+        await expect(async () => await signTypedData(signer, domain, types, value)).rejects.toThrow('User rejected')
+        expect(send).toHaveBeenCalledTimes(1)
+        expect(send).toHaveBeenCalledWith('eth_signTypedData', [wallet, expect.anything()])
+        const data = send.mock.lastCall[1]?.[1]
+        expect(JSON.parse(data)).toEqual(expect.objectContaining({ domain, message: value }))
+      })
     })
   })
 })

--- a/src/provider.ts
+++ b/src/provider.ts
@@ -39,6 +39,7 @@ export async function signTypedData(
    */
   try {
     // MetaMask is known to implement v4. Other wallets should first attempt signTypedData because SafePal hangs on v4.
+    // However, MetaMask will still fallback to sign in case an unknown wallet impersonates MetaMask.
     if (!signer.provider.connection.url.match(/metamask/)) {
       try {
         return await signer.provider.send('eth_signTypedData', [


### PR DESCRIPTION
Updates the logic for signing fallback (ie EIP-712):

- Non-MetaMask will attempt `eth_signTypedData`, using the modern parameter ordering
  - Frame (or any other wallet throwing `unknown account` due to the modern ordering) will then attempt `eth_signTypedData_v4`
- MetaMask will attempt `eth_signTypedData_v4` (which it is known to implement)
- All wallets throwing `not implemented` or `not found` will fall back to `eth_sign`

Also includes inline rationale, and links to relevant resources/documentation.

---

Manually tested on:

- [x] MetaMask
- [x] Stelo (w/ MetaMask)
- [x] Rabby
- [x] SafePal Mobile
- [x] Zerion
- [x] Rainbow
- [x] Trust
- [x] CoinBase Wallet
- [x] Frame
- [x] Argent