### PR TITLE
fix: encode numbers in EIP712 payloads

### DIFF
--- a/src/provider/signing.test.ts
+++ b/src/provider/signing.test.ts
@@ -1,5 +1,5 @@
+import { BigNumber } from '@ethersproject/bignumber'
 import { ExternalProvider, JsonRpcProvider, JsonRpcSigner, Web3Provider } from '@ethersproject/providers'
-import { BigNumber } from 'ethers'
 import { Mutable } from 'types'
 
 import { signTypedData } from '../provider'
@@ -39,12 +39,12 @@ describe('signing', () => {
       },
       contents: 'Hello, Bob!',
       number: 9876543210,
-      bignum: BigNumber.from(1234567890)
+      bignum: BigNumber.from(1234567890),
     }
 
     const encodedValue = {
       ...value,
-      bignum: 1234567890
+      bignum: 1234567890,
     }
 
     let signer: JsonRpcSigner

--- a/src/provider/signing.test.ts
+++ b/src/provider/signing.test.ts
@@ -1,4 +1,5 @@
 import { ExternalProvider, JsonRpcProvider, JsonRpcSigner, Web3Provider } from '@ethersproject/providers'
+import { BigNumber } from 'ethers'
 import { Mutable } from 'types'
 
 import { signTypedData } from '../provider'
@@ -9,7 +10,7 @@ describe('signing', () => {
     const domain = {
       name: 'Ether Mail',
       version: '1',
-      chainId: '1',
+      chainId: 1,
       verifyingContract: '0xcccccccccccccccccccccccccccccccccccccccc',
     }
 
@@ -22,6 +23,8 @@ describe('signing', () => {
         { name: 'from', type: 'Person' },
         { name: 'to', type: 'Person' },
         { name: 'contents', type: 'string' },
+        { name: 'number', type: 'uint256' },
+        { name: 'bignum', type: 'uint256' },
       ],
     }
 
@@ -35,6 +38,13 @@ describe('signing', () => {
         wallet: '0xbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb',
       },
       contents: 'Hello, Bob!',
+      number: 9876543210,
+      bignum: BigNumber.from(1234567890)
+    }
+
+    const encodedValue = {
+      ...value,
+      bignum: 1234567890
     }
 
     let signer: JsonRpcSigner
@@ -66,7 +76,7 @@ describe('signing', () => {
         expect(send).toHaveBeenCalledWith(signingMethod, [wallet, expect.anything()])
         expect(send).toHaveBeenCalledWith('eth_sign', [wallet, expect.anything()])
         const hash = send.mock.lastCall[1]?.[1]
-        expect(hash).toBe('0xbe609aee343fb3c4b28e1df9e632fca64fcfaede20f02e86244efddf30957bd2')
+        expect(hash).toBe('0x997987773a7c24826f4d5bb58a0adb6909636e0a0def99de063639873969ad96')
       })
     }
 
@@ -81,7 +91,7 @@ describe('signing', () => {
         expect(send).toHaveBeenCalledTimes(1)
         expect(send).toHaveBeenCalledWith(signingMethod, [wallet, expect.anything()])
         const data = send.mock.lastCall[1]?.[1]
-        expect(JSON.parse(data)).toEqual(expect.objectContaining({ domain, message: value }))
+        expect(JSON.parse(data)).toEqual(expect.objectContaining({ domain, message: encodedValue }))
       })
     }
 
@@ -95,7 +105,7 @@ describe('signing', () => {
       expect(send).toHaveBeenCalledTimes(1)
       expect(send).toHaveBeenCalledWith('eth_signTypedData_v4', [wallet, expect.anything()])
       const data = send.mock.lastCall[1]?.[1]
-      expect(JSON.parse(data)).toEqual(expect.objectContaining({ domain, message: value }))
+      expect(JSON.parse(data)).toEqual(expect.objectContaining({ domain, message: encodedValue }))
     })
 
     itFallsBackToEthSignIfUnimplemented('eth_signTypedData_v4')
@@ -118,7 +128,7 @@ describe('signing', () => {
           expect(send).toHaveBeenCalledTimes(1)
           expect(send).toHaveBeenCalledWith('eth_signTypedData', [wallet, expect.anything()])
           const data = send.mock.lastCall[1]?.[1]
-          expect(JSON.parse(data)).toEqual(expect.objectContaining({ domain, message: value }))
+          expect(JSON.parse(data)).toEqual(expect.objectContaining({ domain, message: encodedValue }))
         })
 
         itFallsBackToEthSignIfUnimplemented('eth_signTypedData')

--- a/src/provider/signing.ts
+++ b/src/provider/signing.ts
@@ -51,7 +51,7 @@ export async function signTypedData(
   if (payload.domain.chainId) {
     payload.domain.chainId = Number(payload.domain.chainId)
   }
-  payload.message = _TypedDataEncoder.from(types).visit(populated.value, (type: string, value: any) => {
+  payload.message = _TypedDataEncoder.from(types).visit(populated.value, (type: string, value: unknown) => {
     if (type.match(/^u?int/)) {
       return Number(value)
     } else {


### PR DESCRIPTION
According to [EIP-712](https://eips.ethereum.org/EIPS/eip-712#example), numbers should be encoded as numbers, not as strings. This fixes our encoding to do so by modifying the stringified payload using a `String.prototype.replace`.

Without this, some wallets (eg Exodus) will reject the signature request with a chainId mismatch.

---

This should be tested with 3P wallets before merging, as it changes the message that we pass for Permit2.
We should also upstream this change to ethers: https://github.com/ethers-io/ethers.js/blob/278f84174409b470fa7992e1f8b5693e6e5d2dac/src.ts/hash/typed-data.ts#L471.