### PR TITLE
fix: fallback to eth_sign for trustwallet failure

### DIFF
--- a/src/provider/signing.ts
+++ b/src/provider/signing.ts
@@ -50,7 +50,10 @@ export async function signTypedData(
     return await signer.provider.send(method, [address, message])
   } catch (error) {
     // If eth_signTypedData is unimplemented, fall back to eth_sign.
-    if (typeof error.message === 'string' && error.message.match(/not (found|implemented)/i)) {
+    if (
+      typeof error.message === 'string' &&
+      (error.message.match(/not (found|implemented)/i) || error.message.match(/TrustWalletConnect.WCError error 1/))
+    ) {
       console.warn('signTypedData: wallet does not implement EIP-712, falling back to eth_sign', error.message)
       const hash = _TypedDataEncoder.hash(populated.domain, types, populated.value)
       return await signer.provider.send('eth_sign', [address, hash])


### PR DESCRIPTION
Trust Wallet is throwing this Error for `eth_signTypedData` and `eth_signTypedData_v4` on layer 2 networks:

```
{code: -32000, message: 'The operation couldn't be completed. (TrustWalletConnect.WCError error 1.)'}
```

falling back to the classic `eth_sign` standard is a short term workaround until we work with them to understand why the requests are failing. 