### PR TITLE
feat: update to mobile's latest format.ts changes

### DIFF
--- a/src/format.test.ts
+++ b/src/format.test.ts
@@ -111,12 +111,12 @@ it('formats NFT numbers correctly', () => {
   expect(formatNumber(12.1, NumberType.NFTTokenFloorPriceTrailingZeros)).toBe('12.10')
   expect(formatNumber(0.09001, NumberType.NFTTokenFloorPriceTrailingZeros)).toBe('0.090')
 
-  expect(formatNumber(0.987654321, NumberType.NFTCollectionStats)).toBe('0.98765')
-  expect(formatNumber(0.9, NumberType.NFTCollectionStats)).toBe('0.9')
-  expect(formatNumber(76543.21, NumberType.NFTCollectionStats)).toBe('76543.2')
-  expect(formatNumber(7.60000054321, NumberType.NFTCollectionStats)).toBe('7.6')
-  expect(formatNumber(1234567890, NumberType.NFTCollectionStats)).toBe('1.23457B')
-  expect(formatNumber(1234567000000000, NumberType.NFTCollectionStats)).toBe('>999T')
+  expect(formatNumber(0.987654321, NumberType.NFTCollectionStats)).toBe('1')
+  expect(formatNumber(0.9, NumberType.NFTCollectionStats)).toBe('1')
+  expect(formatNumber(76543.21, NumberType.NFTCollectionStats)).toBe('76.5K')
+  expect(formatNumber(7.60000054321, NumberType.NFTCollectionStats)).toBe('8')
+  expect(formatNumber(1234567890, NumberType.NFTCollectionStats)).toBe('1.2B')
+  expect(formatNumber(1234567000000000, NumberType.NFTCollectionStats)).toBe('1234.6T')
 })
 
 describe('formatUSDPrice', () => {
@@ -136,7 +136,7 @@ describe('formatUSDPrice', () => {
     expect(formatUSDPrice(0)).toBe('$0.00')
   })
   it('should correctly format 1.048942', () => {
-    expect(formatUSDPrice(1.048942)).toBe('$1.049')
+    expect(formatUSDPrice(1.048942)).toBe('$1.05')
   })
   it('should correctly format 0.10235', () => {
     expect(formatUSDPrice(0.10235)).toBe('$0.102')
@@ -151,7 +151,7 @@ describe('formatUSDPrice', () => {
     expect(formatUSDPrice(1_000_000_000_000)).toBe('$1.00T')
   })
   it('should correctly format 1000000000000000', () => {
-    expect(formatUSDPrice(1_000_000_000_000_000)).toBe('>$999T')
+    expect(formatUSDPrice(1_000_000_000_000_000)).toBe('$1000.00T')
   })
 })
 

--- a/src/format.ts
+++ b/src/format.ts
@@ -170,6 +170,7 @@ const swapPriceFormatter: FormatterRule[] = [
 ]
 
 const fiatTokenDetailsFormatter: FormatterRule[] = [
+  { exact: 0, formatter: '$0.00' },
   { upperBound: 0.00000001, formatter: '<$0.00000001' },
   { upperBound: 0.1, formatter: THREE_SIG_FIGS_USD },
   { upperBound: 1.05, formatter: THREE_DECIMALS_USD },
@@ -178,6 +179,7 @@ const fiatTokenDetailsFormatter: FormatterRule[] = [
 ]
 
 const fiatTokenPricesFormatter: FormatterRule[] = [
+  { exact: 0, formatter: '$0.00' },
   { upperBound: 0.00000001, formatter: '<$0.00000001' },
   { upperBound: 1, formatter: THREE_SIG_FIGS_USD },
   { upperBound: 1e6, formatter: TWO_DECIMALS_USD },

--- a/src/format.ts
+++ b/src/format.ts
@@ -5,11 +5,6 @@ import { Nullish } from './types'
 // Number formatting follows the standards laid out in this spec:
 // https://www.notion.so/uniswaplabs/Number-standards-fbb9f533f10e4e22820722c2f66d23c0
 
-const FIVE_DECIMALS_NO_TRAILING_ZEROS = new Intl.NumberFormat('en-US', {
-  notation: 'standard',
-  maximumFractionDigits: 5,
-})
-
 const FIVE_DECIMALS_MAX_TWO_DECIMALS_MIN = new Intl.NumberFormat('en-US', {
   notation: 'standard',
   maximumFractionDigits: 5,
@@ -21,6 +16,12 @@ const FIVE_DECIMALS_MAX_TWO_DECIMALS_MIN_NO_COMMAS = new Intl.NumberFormat('en-U
   maximumFractionDigits: 5,
   minimumFractionDigits: 2,
   useGrouping: false,
+})
+
+const NO_DECIMALS = new Intl.NumberFormat('en-US', {
+  notation: 'standard',
+  maximumFractionDigits: 0,
+  minimumFractionDigits: 0,
 })
 
 const THREE_DECIMALS_NO_TRAILING_ZEROS = new Intl.NumberFormat('en-US', {
@@ -73,9 +74,10 @@ const SHORTHAND_TWO_DECIMALS_NO_TRAILING_ZEROS = new Intl.NumberFormat('en-US', 
   maximumFractionDigits: 2,
 })
 
-const SHORTHAND_FIVE_DECIMALS_NO_TRAILING_ZEROS = new Intl.NumberFormat('en-US', {
+const SHORTHAND_ONE_DECIMAL = new Intl.NumberFormat('en-US', {
   notation: 'compact',
-  maximumFractionDigits: 5,
+  minimumFractionDigits: 1,
+  maximumFractionDigits: 1,
 })
 
 const SHORTHAND_USD_TWO_DECIMALS = new Intl.NumberFormat('en-US', {
@@ -161,8 +163,13 @@ const swapTradeAmountFormatter: FormatterRule[] = [
   { upperBound: Infinity, formatter: SIX_SIG_FIGS_TWO_DECIMALS_NO_COMMAS },
 ]
 
+const swapPriceFormatter: FormatterRule[] = [
+  { exact: 0, formatter: '0' },
+  { upperBound: 0.00001, formatter: '<0.00001' },
+  ...swapTradeAmountFormatter,
+]
+
 const fiatTokenDetailsFormatter: FormatterRule[] = [
-  { exact: 0, formatter: '$0.00' },
   { upperBound: 0.00000001, formatter: '<$0.00000001' },
   { upperBound: 0.1, formatter: THREE_SIG_FIGS_USD },
   { upperBound: 1.05, formatter: THREE_DECIMALS_USD },
@@ -171,13 +178,10 @@ const fiatTokenDetailsFormatter: FormatterRule[] = [
 ]
 
 const fiatTokenPricesFormatter: FormatterRule[] = [
-  { exact: 0, formatter: '$0.00' },
   { upperBound: 0.00000001, formatter: '<$0.00000001' },
-  { upperBound: 0.1, formatter: THREE_SIG_FIGS_USD }, // Round to 3 significant figures, show significant trailing zeros
-  { upperBound: 1.05, formatter: THREE_DECIMALS_USD }, // Round to 3 decimal places, show significant trailing zeros
-  { upperBound: 1_000_000, formatter: TWO_DECIMALS_USD }, // Round to 2 decimal places
-  { upperBound: 1_000_000_000_000_000, formatter: SHORTHAND_USD_TWO_DECIMALS }, // Use M/B/T abbreviations
-  { upperBound: Infinity, formatter: '>$999T' }, // Use M/B/T abbreviations
+  { upperBound: 1, formatter: THREE_SIG_FIGS_USD },
+  { upperBound: 1e6, formatter: TWO_DECIMALS_USD },
+  { upperBound: Infinity, formatter: SHORTHAND_USD_TWO_DECIMALS },
 ]
 
 const fiatTokenStatsFormatter: FormatterRule[] = [
@@ -220,12 +224,8 @@ const ntfTokenFloorPriceFormatter: FormatterRule[] = [
 ]
 
 const ntfCollectionStatsFormatter: FormatterRule[] = [
-  { exact: 0, formatter: '0' },
-  { upperBound: 0.00001, formatter: '<0.00001' },
-  { upperBound: 1, formatter: FIVE_DECIMALS_NO_TRAILING_ZEROS },
-  { upperBound: 1e6, formatter: SIX_SIG_FIGS_NO_COMMAS },
-  { upperBound: 1e15, formatter: SHORTHAND_FIVE_DECIMALS_NO_TRAILING_ZEROS },
-  { upperBound: Infinity, formatter: '>999T' },
+  { upperBound: 1000, formatter: NO_DECIMALS },
+  { upperBound: Infinity, formatter: SHORTHAND_ONE_DECIMAL },
 ]
 
 export enum NumberType {
@@ -234,6 +234,10 @@ export enum NumberType {
 
   // used for token quantities in transaction contexts (e.g. swap, send)
   TokenTx = 'token-tx',
+
+  // this formatter is used for displaying swap price conversions
+  // below the input/output amounts
+  SwapPrice = 'swap-price',
 
   // this formatter is only used for displaying the swap trade output amount
   // in the text input boxes. Output amounts on review screen should use the above TokenTx formatter
@@ -270,6 +274,7 @@ export enum NumberType {
 const TYPE_TO_FORMATTER_RULES = {
   [NumberType.TokenNonTx]: tokenNonTxFormatter,
   [NumberType.TokenTx]: tokenTxFormatter,
+  [NumberType.SwapPrice]: swapPriceFormatter,
   [NumberType.SwapTradeAmount]: swapTradeAmountFormatter,
   [NumberType.FiatTokenQuantity]: fiatTokenQuantityFormatter,
   [NumberType.FiatTokenDetails]: fiatTokenDetailsFormatter,
@@ -282,10 +287,9 @@ const TYPE_TO_FORMATTER_RULES = {
   [NumberType.NFTCollectionStats]: ntfCollectionStatsFormatter,
 }
 
-function getFormatterRule(input: number, type: NumberType) {
+function getFormatterRule(input: number, type: NumberType): Format {
   const rules = TYPE_TO_FORMATTER_RULES[type]
-  for (let i = 0; i < rules.length; i++) {
-    const rule = rules[i]
+  for (const rule of rules) {
     if (
       (rule.exact !== undefined && input === rule.exact) ||
       (rule.upperBound !== undefined && input < rule.upperBound)
@@ -297,7 +301,11 @@ function getFormatterRule(input: number, type: NumberType) {
   throw new Error(`formatter for type ${type} not configured correctly`)
 }
 
-export function formatNumber(input: Nullish<number>, type: NumberType = NumberType.TokenNonTx, placeholder = '-') {
+export function formatNumber(
+  input: Nullish<number>,
+  type: NumberType = NumberType.TokenNonTx,
+  placeholder = '-'
+): string {
   if (input === null || input === undefined) {
     return placeholder
   }
@@ -311,11 +319,11 @@ export function formatCurrencyAmount(
   amount: Nullish<CurrencyAmount<Currency>>,
   type: NumberType = NumberType.TokenNonTx,
   placeholder?: string
-) {
+): string {
   return formatNumber(amount ? parseFloat(amount.toSignificant()) : undefined, type, placeholder)
 }
 
-export function formatPriceImpact(priceImpact: Percent | undefined) {
+export function formatPriceImpact(priceImpact: Percent | undefined): string {
   if (!priceImpact) return '-'
 
   return `${priceImpact.multiply(-1).toFixed(3)}%`
@@ -327,7 +335,10 @@ export function formatSlippage(slippage: Percent | undefined) {
   return `${slippage.toFixed(3)}%`
 }
 
-export function formatPrice(price: Nullish<Price<Currency, Currency>>, type: NumberType = NumberType.FiatTokenPrice) {
+export function formatPrice(
+  price: Nullish<Price<Currency, Currency>>,
+  type: NumberType = NumberType.FiatTokenPrice
+): string {
   if (price === null || price === undefined) {
     return '-'
   }
@@ -339,7 +350,7 @@ export function formatPrice(price: Nullish<Price<Currency, Currency>>, type: Num
  * Very simple date formatter
  * Feel free to add more options / adapt to your needs.
  */
-export function formatDate(date: Date) {
+export function formatDate(date: Date): string {
   return date.toLocaleString('en-US', {
     day: 'numeric', // numeric, 2-digit
     year: 'numeric', // numeric, 2-digit
@@ -349,12 +360,18 @@ export function formatDate(date: Date) {
   })
 }
 
-export function formatNumberOrString(price: Nullish<number | string>, type: NumberType) {
+export function formatNumberOrString(price: Nullish<number | string>, type: NumberType): string {
   if (price === null || price === undefined) return '-'
   if (typeof price === 'string') return formatNumber(parseFloat(price), type)
   return formatNumber(price, type)
 }
 
-export function formatUSDPrice(price: Nullish<number | string>, type: NumberType = NumberType.FiatTokenPrice) {
+export function formatUSDPrice(price: Nullish<number | string>, type: NumberType = NumberType.FiatTokenPrice): string {
   return formatNumberOrString(price, type)
+}
+
+/** Formats USD and non-USD prices */
+export function formatFiatPrice(price: Nullish<number>, currency = 'USD'): string {
+  if (price === null || price === undefined) return '-'
+  return new Intl.NumberFormat('en-US', { style: 'currency', currency }).format(price)
 }


### PR DESCRIPTION
the wallet repo doesn't actually use coned, so coned/interface doesn't have some of their latest changes to number formatting. This PR pulls in those recent changes, including getting rid of stablecoin prices having three trailing 0's like '$1.000'

tested using yarn link