### PR TITLE
fix: format gas price 0

### DIFF
--- a/src/format.test.ts
+++ b/src/format.test.ts
@@ -69,6 +69,7 @@ it('formats gas USD prices correctly', () => {
   expect(formatNumber(1234567.891, NumberType.FiatGasPrice)).toBe('$1.23M')
   expect(formatNumber(18.448, NumberType.FiatGasPrice)).toBe('$18.45')
   expect(formatNumber(0.0099, NumberType.FiatGasPrice)).toBe('<$0.01')
+  expect(formatNumber(0, NumberType.FiatGasPrice)).toBe('$0.00')
 })
 
 it('formats USD token quantities prices correctly', () => {

--- a/src/format.ts
+++ b/src/format.ts
@@ -195,6 +195,7 @@ const fiatTokenStatsFormatter: FormatterRule[] = [
 ]
 
 const fiatGasPriceFormatter: FormatterRule[] = [
+  { exact: 0, formatter: '$0.00'},
   { upperBound: 0.01, formatter: '<$0.01' },
   { upperBound: 1e6, formatter: TWO_DECIMALS_USD },
   { upperBound: Infinity, formatter: SHORTHAND_USD_TWO_DECIMALS },


### PR DESCRIPTION
Fixes `fiatGasPriceFormatter` to format gas to `$0.00` if gas is `0` instead of `<$0.01`