### PR TITLE
fix: change extremely large numbers to sci not

### DIFF
--- a/src/format.test.ts
+++ b/src/format.test.ts
@@ -53,6 +53,7 @@ it('formats fiat estimates for tokens correctly', () => {
 
   expect(formatNumber(0.0000001234, NumberType.FiatTokenPrice)).toBe('$0.000000123')
   expect(formatNumber(0.000000009876, NumberType.FiatTokenPrice)).toBe('<$0.00000001')
+  expect(formatNumber(10000000000000000000000000000000, NumberType.FiatTokenPrice)).toBe('$1.000000E31')
 })
 
 it('formats fiat estimates for token stats correctly', () => {

--- a/src/format.ts
+++ b/src/format.ts
@@ -127,6 +127,14 @@ const THREE_SIG_FIGS_USD = new Intl.NumberFormat('en-US', {
   style: 'currency',
 })
 
+const SEVEN_SIG_FIGS__SCI_NOTATION_USD = new Intl.NumberFormat('en-US', {
+  notation: 'scientific',
+  minimumSignificantDigits: 7,
+  maximumSignificantDigits: 7,
+  currency: 'USD',
+  style: 'currency',
+})
+
 type Format = Intl.NumberFormat | string
 
 // each rule must contain either an `upperBound` or an `exact` value.
@@ -183,7 +191,8 @@ const fiatTokenPricesFormatter: FormatterRule[] = [
   { upperBound: 0.00000001, formatter: '<$0.00000001' },
   { upperBound: 1, formatter: THREE_SIG_FIGS_USD },
   { upperBound: 1e6, formatter: TWO_DECIMALS_USD },
-  { upperBound: Infinity, formatter: SHORTHAND_USD_TWO_DECIMALS },
+  { upperBound: 1e16, formatter: SHORTHAND_USD_TWO_DECIMALS },
+  { upperBound: Infinity, formatter: SEVEN_SIG_FIGS__SCI_NOTATION_USD },
 ]
 
 const fiatTokenStatsFormatter: FormatterRule[] = [


### PR DESCRIPTION
Changes `fiatTokenPricesFormatter` to format numbers larger than `1e16` to a 7 significant figure, scientific notion form to prevent text from wrapping on the interface. 