### PR TITLE
fix: Correctly encode chainId attribute of EIP-712 messages

### DIFF
--- a/src/provider/signing.test.ts
+++ b/src/provider/signing.test.ts
@@ -9,7 +9,13 @@ describe('signing', () => {
     const domain = {
       name: 'Ether Mail',
       version: '1',
-      chainId: '1',
+      chainId: 1,
+      verifyingContract: '0xcccccccccccccccccccccccccccccccccccccccc',
+    }
+
+    const domainNoChain = {
+      name: 'Ether Mail',
+      version: '1',
       verifyingContract: '0xcccccccccccccccccccccccccccccccccccccccc',
     }
 
@@ -96,6 +102,15 @@ describe('signing', () => {
       expect(send).toHaveBeenCalledWith('eth_signTypedData_v4', [wallet, expect.anything()])
       const data = send.mock.lastCall[1]?.[1]
       expect(JSON.parse(data)).toEqual(expect.objectContaining({ domain, message: value }))
+    })
+
+    it('does not fail when domain.chainId is not defined', async () => {
+      const send = jest.spyOn(signer.provider, 'send').mockImplementationOnce(() => Promise.resolve())
+
+      await signTypedData(signer, domainNoChain, types, value)
+      expect(send).toHaveBeenCalledTimes(1)
+      const data = send.mock.lastCall[1]?.[1]
+      expect(JSON.parse(data)).toEqual(expect.objectContaining({ domain: domainNoChain, message: value }))
     })
 
     itFallsBackToEthSignIfUnimplemented('eth_signTypedData_v4')

--- a/src/provider/signing.ts
+++ b/src/provider/signing.ts
@@ -44,7 +44,12 @@ export async function signTypedData(
 
   const method = supportsV4(signer.provider) ? 'eth_signTypedData_v4' : 'eth_signTypedData'
   const address = (await signer.getAddress()).toLowerCase()
-  const message = JSON.stringify(_TypedDataEncoder.getPayload(populated.domain, types, populated.value))
+  const payload = _TypedDataEncoder.getPayload(populated.domain, types, populated.value)
+
+  // TODO(WEB-000): remove string to number parsing after Ethers v6 migration
+  payload.domain.chainId = payload.domain.chainId != null ? Number(payload.domain.chainId) : undefined
+
+  const message = JSON.stringify(payload)
 
   try {
     return await signer.provider.send(method, [address, message])


### PR DESCRIPTION
The `chainId` attribute of the EIP-712 messages should be a number and not a string as specified on the [spec](https://eips.ethereum.org/EIPS/eip-712):
> uint256 chainId the [EIP-155](https://eips.ethereum.org/EIPS/eip-155) chain id. The user-agent should refuse signing if it does not match the currently active chain.

The latest ^5 version of EthersJs still parses the `chainId` attribute to a string (see code [here](https://github.com/ethers-io/ethers.js/blob/v5/packages/hash/src.ts/typed-data.ts#L60)) and this has only been fixed on the new ^6 version (see [here](https://github.com/ethers-io/ethers.js/blob/main/src.ts/hash/typed-data.ts)).

As these EIP-712 messages have the `chainId` set as string, the [Wagmi](https://github.com/wagmi-dev/wagmi) library throws an error when trying to sign the typed message because "1" !== 1 (see [signTypedData](https://github.com/wagmi-dev/wagmi/blob/main/packages/core/src/actions/accounts/signTypedData.ts#L40) and [assetActiveChain](https://github.com/wagmi-dev/wagmi/blob/main/packages/core/src/utils/assertActiveChain.ts#L8))

Please consider having a look at this PR as I suppose that a migration to Ethersjs v6 is not coming soon 🙏🏻 